### PR TITLE
Fix email validation regex

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,7 +41,9 @@ const validateField = (field, errorId, errorMessage) => {
 
 // Validate email field with custom validation
 const validateEmailField = (field, errorId, errorMessage) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,24}$/;
+    // Accept domains with multiple segments (e.g. example.co.uk)
+    // First segment cannot contain a dot to avoid matching "domain..com"
+    const emailRegex = /^[^\s@]+@[^\s@.]+(\.[^\s@.]{2,})+$/;
     const errorElement = document.getElementById(errorId);
 
     if (!emailRegex.test(field.value)) {


### PR DESCRIPTION
## Summary
- update email validation to allow multiple domain segments

## Testing
- `node - <<'EOF'
const regex=/^[^\s@]+@[^\s@.]+(\.[^\s@.]{2,})+$/;
let good=['john@mail.co.uk','foo@example.com','john@example.co.uk'];
let bad=['noatsign','john@','john@domain','john@domain.c','john@domain..com'];
console.log('Good:');good.forEach(x=>console.log(x, regex.test(x)));
console.log('Bad:');bad.forEach(x=>console.log(x, regex.test(x)));
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686666cfa9708329aaf872a0cf275de5